### PR TITLE
Add automatic layout fallback for single-unit armies

### DIFF
--- a/src/layouts.rs
+++ b/src/layouts.rs
@@ -191,3 +191,57 @@ pub fn canonicalize_counts(
     }
     map
 }
+
+pub fn select_layout(
+    layouts: &[LayoutEntry],
+    side: SideKind,
+    counts: &BTreeMap<String, usize>,
+) -> Option<Vec<Vec<Option<String>>>> {
+    if let Some(entry) = find_layout_entry(layouts, side, counts) {
+        Some(entry.grid.clone())
+    } else if counts.len() == 1 {
+        let (unit, &num) = counts.iter().next().unwrap();
+        Some(single_unit_layout(side, unit, num))
+    } else {
+        None
+    }
+}
+
+fn single_unit_layout(
+    side: SideKind,
+    unit: &str,
+    count: usize,
+) -> Vec<Vec<Option<String>>> {
+    let picture = u_picture(count);
+    picture
+        .into_iter()
+        .map(|row| {
+            let mut cells: Vec<Option<String>> = row
+                .chars()
+                .map(|ch| if ch == 'U' { Some(unit.to_string()) } else { None })
+                .collect();
+            if side == SideKind::Right {
+                cells.reverse();
+            }
+            cells
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fallback_single_unit_layout_right() {
+        let layouts: Vec<LayoutEntry> = vec![];
+        let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+        counts.insert("Dragon".into(), 3);
+        let grid = select_layout(&layouts, SideKind::Right, &counts).unwrap();
+        let expected = vec![
+            vec![Some("Dragon".into()), Some("Dragon".into())],
+            vec![Some("Dragon".into()), None],
+        ];
+        assert_eq!(grid, expected);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::fs;
-use tt2_bt_sim::layouts::{canonicalize_counts, find_layout_entry, parse_layouts, SideKind};
+use tt2_bt_sim::layouts::{canonicalize_counts, parse_layouts, select_layout, SideKind};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -225,10 +225,8 @@ fn main() -> Result<()> {
         att_counts_raw.push((h.name.clone(), 1));
     }
     let att_counts = canonicalize_counts(&att_counts_raw, &abbr_map);
-    let att_template = find_layout_entry(&layouts, SideKind::Left, &att_counts)
-        .ok_or_else(|| anyhow!("No matching layout for attacker"))?
-        .grid
-        .clone();
+    let att_template = select_layout(&layouts, SideKind::Left, &att_counts)
+        .ok_or_else(|| anyhow!("No matching layout for attacker"))?;
 
     let def_counts_raw: Vec<(String, usize)> = cfg
         .defender
@@ -237,10 +235,8 @@ fn main() -> Result<()> {
         .map(|cu| (cu.kind.clone(), cu.count))
         .collect();
     let def_counts = canonicalize_counts(&def_counts_raw, &abbr_map);
-    let def_template = find_layout_entry(&layouts, SideKind::Right, &def_counts)
-        .ok_or_else(|| anyhow!("No matching layout for defender"))?
-        .grid
-        .clone();
+    let def_template = select_layout(&layouts, SideKind::Right, &def_counts)
+        .ok_or_else(|| anyhow!("No matching layout for defender"))?;
 
     let mut state = BattleState {
         round: 0,
@@ -1011,10 +1007,7 @@ mod tests {
             ("Hero".to_string(), 1),
         ];
         let counts = canonicalize_counts(&raw_counts, &abbr);
-        let template = find_layout_entry(&layouts, SideKind::Left, &counts)
-            .unwrap()
-            .grid
-            .clone();
+        let template = select_layout(&layouts, SideKind::Left, &counts).unwrap();
         let mut form = Formation::new(Side::Attacker, SideModifiers::default(), template);
 
         for _ in 0..18 {


### PR DESCRIPTION
## Summary
- generate layouts for single-unit rosters via `u_picture` when no entry exists
- prevent "No matching layout" errors for defenders
- cover new behavior with unit tests

## Testing
- `cargo test`
- `cargo run battle.json`

------
https://chatgpt.com/codex/tasks/task_e_68c1eae584e083239e1689848b6399cb