### PR TITLE
Fix regen logic and target selection persistence

### DIFF
--- a/src/layouts.rs
+++ b/src/layouts.rs
@@ -254,10 +254,10 @@ mod tests {
         let grid = select_layout(&layouts, SideKind::Right, &counts).unwrap();
         let expected = vec![
             LayoutLine {
-                units: vec![UnitKind::BroilerDragon],
+                units: vec![UnitKind::BroilerDragon, UnitKind::BroilerDragon],
             },
             LayoutLine {
-                units: vec![UnitKind::BroilerDragon, UnitKind::BroilerDragon],
+                units: vec![UnitKind::BroilerDragon],
             },
         ];
         assert_eq!(grid, expected);


### PR DESCRIPTION
## Summary
- skip hero regeneration when already at full health
- track per-unit targeting progress and reset when formations repack
- repack armies only when units die and ignore dead units for healing
- add unit tests for target progression and dead-unit handling

## Testing
- `cargo test`
- `cargo run battle.json`

------
https://chatgpt.com/codex/tasks/task_e_68c5c2628b2083239a35be2ce0dfc43a